### PR TITLE
Add Chromium submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "chromium"]
 	path = chromium
-	url = ./chromium
+	url = git@github.com:ECS-251-W2020/chromium.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "chromium"]
+	path = chromium
+	url = ./chromium

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Garnet
 
 A prototype of remote browser isolation system that intercepts draw commands in remote browser and replays them via WebAssembly in local browser.
+
+## Setup Chromium
+
+TBD...

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# final-project-sudo-team
+# Garnet
+
+A prototype of remote browser isolation system that intercepts draw commands in remote browser and replays them via WebAssembly in local browser.


### PR DESCRIPTION
Because building Chromium requires a separate tool from Google, we may not simply `git submodule update` to build it. So this submodule is more of a "placeholder" for now, we'll see what's the best way to get the build.